### PR TITLE
Correções

### DIFF
--- a/app/assets/javascripts/materialize/chips.js
+++ b/app/assets/javascripts/materialize/chips.js
@@ -161,7 +161,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
           var index = $chip.index();
           if (clickedClose) {
             // delete chip
-            this.deleteChip(index);
+            this.deleteChip(index - 1);
             this.$input[0].focus();
           } else {
             // select chip
@@ -406,9 +406,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         this._setPlaceholder();
 
         // fire chipDelete callback
-        if (typeof this.options.onChipDelete === 'function') {
-          this.options.onChipDelete.call(this, this.$el, $chip[0]);
-        }
+        
+        this.options.onChipDelete.call(this, this.$el, $chip[0]);
       }
 
       /**

--- a/app/controllers/arenas_controller.rb
+++ b/app/controllers/arenas_controller.rb
@@ -30,7 +30,6 @@ class ArenasController < ApplicationController
 
     respond_to do |format|
       if @arena.save
-        sync_new @arena
         format.html { redirect_to arenas_url, notice: 'Arena was successfully created.' }
         format.json { render :show, status: :created, location: @arena }
       else

--- a/app/controllers/hours_controller.rb
+++ b/app/controllers/hours_controller.rb
@@ -5,6 +5,9 @@ class HoursController < ApplicationController
   # GET /hours
   # GET /hours.json
   def index
+    @hour = Hour.new
+    @date = Date.current
+    @arenas = Arena.all
     @hours = Hour.all.order(date: :desc)
   end
 
@@ -27,18 +30,27 @@ class HoursController < ApplicationController
   # POST /hours
   # POST /hours.json
   def create
-    @hour = Hour.new(hour_params)    
-
-    respond_to do |format|
-      if @hour.save
-        format.html { redirect_to hours_url, notice: 'Hour was successfully created.' }
-        format.json { render :show, status: :created, location: @hour }
-      else
-        @arenas = Arena.all
-        format.html { render :new }
-        format.json { render json: @hour.errors, status: :unprocessable_entity }
-      end
+    
+    params[:date].each do |date|
+      @hour = Hour.new(hour_params)
+      @hour.date = date
+      @hour.save
     end
+    respond_to do |format|
+      format.html { redirect_to hours_url, notice: 'Hour was successfully created.' }
+      format.json { render :show, status: :created, location: @hour }
+    end
+
+    # respond_to do |format|
+    #   if @hour.save
+    #     format.html { redirect_to hours_url, notice: 'Hour was successfully created.' }
+    #     format.json { render :show, status: :created, location: @hour }
+    #   else
+    #     @arenas = Arena.all
+    #     format.html { render :new }
+    #     format.json { render json: @hour.errors, status: :unprocessable_entity }
+    #   end
+    # end
   end
 
   # PATCH/PUT /hours/1

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -20,7 +20,7 @@ class PaymentsController < ApplicationController
           format.json { render json: @payment.errors, status: :unprocessable_entity }
         end
       else
-        format.html { redirect_to schedules_url, notice: 'You already have two current appointments.' }
+        format.html { redirect_to schedules_url, notice: 'Already have two current appointments.' }
         format.json { render json: @payment, status: :unprocessable_entity }
       end
     end

--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -13,6 +13,10 @@ class Hour < ApplicationRecord
     schedules.where(:status => 'true').count == 0
   end
 
+  def user_scheduled
+    schedules.where(status: 'true').first.user
+  end
+
   def period!
     "#{time.hour}:00h as #{time.hour+1}:00h"
   end

--- a/app/views/hours/_form.html.erb
+++ b/app/views/hours/_form.html.erb
@@ -3,7 +3,7 @@
     <i class="material-icons prefix">golf_course</i>
     <select name="hour[arena_id]" id="hour_arena_id">
       <option value="" disabled selected>Choose arena</option>
-      <% @arenas.each do |arena| %>      
+      <% @arenas.each do |arena| %>
         <option value="<%= arena.id %>"><%= arena.name %></option>
       <% end %>
     </select>

--- a/app/views/hours/index.html.erb
+++ b/app/views/hours/index.html.erb
@@ -1,28 +1,17 @@
 <h1 class="header">Hours</h1>
 
-<%= link_to 'New Hour', new_hour_path, class: "btn-flat teal lighten-5" %>
-
-<table class="highlight">
-  <thead>
-    <tr>
-      <th>Arena</th>
-      <th>Cost</th>
-      <th>Date</th>
-      <th>Hour</th>      
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @hours.each do |hour| %>
-      <tr>
-        <td><%= hour.arena.name %></td>        
-        <td>R$ <%= hour.cost %></td>
-        <td><%= hour.date! %></td>
-        <td><%= hour.period! %></td>
-        <td><%= link_to 'Edit', edit_hour_path(hour), :class => "btn-flat blue lighten-5" %></td>
-        <td><%= link_to 'Destroy', hour, method: :delete, data: { confirm: 'Are you sure?' }, :class => "btn-flat deep-orange accent-1" %></td>
-      </tr>
+<div class="row">
+    <div class="col s12">
+        <ul class="tabs">
+            <% @arenas.each do |arena| %>    
+                <li class="tab"><a href="#arena_<%= arena.id %>"><%= arena.name %></a></li>    
+            <% end %>
+        </ul>
+    </div>
+    <% @arenas.each do |arena| %>
+        <p></p>
+        <div id="arena_<%= arena.id %>" class="col s12">
+          <%= sync partial: 'arena-admin', resource: arena %>            
+        </div
     <% end %>
-  </tbody>
-</table>
+</div>

--- a/app/views/hours/index.html.erb
+++ b/app/views/hours/index.html.erb
@@ -1,5 +1,10 @@
 <h1 class="header">Hours</h1>
 
+<% if @arenas.empty? %>
+    <p class="header">No registered arena.</p>
+    <%= link_to 'New Arena', new_arena_path, class: "btn-flat teal lighten-5" %>
+<% end %>
+
 <div class="row">
     <div class="col s12">
         <ul class="tabs">

--- a/app/views/hours/show.html.erb
+++ b/app/views/hours/show.html.erb
@@ -1,0 +1,38 @@
+<p>
+  <strong>Date:</strong>
+  <%= @hour.date! %>
+</p>
+
+<p>
+  <strong>Time:</strong>
+  <%= @hour.period! %>
+</p>
+
+<p>
+  <strong>Cost:</strong>
+  R$ <%= @hour.cost %>
+</p>
+
+<p>
+  <strong>Arena:</strong>
+  <%= @hour.arena.name %>
+</p>
+
+<% if !@hour.available? %>
+  ---------------------------------------------------
+  <br>
+  <strong>Scheduled to:</strong>
+  <%= @hour.user_scheduled.name %>
+  <br>
+  email: <%= @hour.user_scheduled.email %>
+  <br>
+  address: <%= @hour.user_scheduled.address %>
+  <br>
+  <br>
+  <%= link_to 'Back', hours_path, :class => "btn-flat blue lighten-5" %>
+<% else %>
+  <%= link_to 'Back', hours_path, :class => "btn-flat blue lighten-5" %>
+  <%= link_to 'Edit', edit_hour_path(@hour), :class => "btn-flat blue lighten-5" %>
+  <%= link_to 'Destroy', @hour, method: :delete, data: { confirm: 'Are you sure?' }, :class => "btn-flat deep-orange accent-1" %>
+<% end %>
+

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -16,21 +16,23 @@
     <ul id="nav-mobile" class="sidenav sidenav-fixed">
         <li class="logo">
           <%= image_tag("logo.jpg") %>
-        </li>
-        <li class="bold">
-          <%= link_to('Schedules', root_path) %>
-        </li>             
+        </li>                    
         <% if current_user.admin %>
-          <li class="bold">
-            <%= link_to('Hours', hours_path) %>
-          </li>
           <li class="bold">
             <%= link_to('Arenas', arenas_path) %>
           </li>
           <li class="bold">
+            <%= link_to('Hours', hours_path) %>
+          </li>         
+        <% end %>
+        <li class="bold">
+          <%= link_to('Schedules', root_path) %>
+        </li> 
+        <% if current_user.admin %>
+          <li class="bold">
             <%= link_to('Users', users_path) %>
           </li>
-        <% end %>
+        <% end %>        
         <li class="bold">
           <%= link_to "Update your information", edit_user_registration_path %>
         </li>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,6 +1,7 @@
 <h1 class="header">Schedules</h1>
-
-<%= link_to 'New Schedule', new_schedule_path, class: "btn-flat teal lighten-5" %>
+<% if !current_user.admin %>
+  <%= link_to 'New Schedule', new_schedule_path, class: "btn-flat teal lighten-5" %>
+<% end %>
 
 <table class="highlight">
   <thead>
@@ -26,13 +27,13 @@
         <td><%= schedule.hour.date! %></td>
         <td><%= schedule.hour.period! %></td>
         <td><%= schedule.status! %></td>
-        <% if !schedule.payment_status? %>
+        <% if !schedule.payment_status? && current_user.admin %>
           <td>
             <%= form_with(model: schedule.payments.new, local: true) do |form| %>
               <%= form.hidden_field :schedule_id, value: schedule.id %>
               <%= form.hidden_field :form, value: "Credit Card"  %>
               <%= form.hidden_field :value, value: schedule.hour.cost  %>
-              <%= form.submit "Pay schedule", class: "btn-flat deep-orange accent-1" %>
+              <%= form.submit "Confirm payment", class: "btn-flat deep-orange accent-1" %>
             <% end %>
           </td>
         <% elsif schedule.status? %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -6,12 +6,26 @@
     </div>    
 </header>
 
-<p class="header">Click on the available hour in the calendar of the desired arena.</p>
+<p class="header">Select the desired arena and choose an available time.</p>
 
-<% @arenas.each do |arena| %>
-    <p class="header right"><%= @date.strftime('%B of %Y') %></p> 
-    <%= sync partial: 'arena', resource: arena %>
-    <p class="header"><%= arena.name %></p> 
-<% end %>
+<div class="row">
+    <div class="col s12">
+        <ul class="tabs">
+            <% @arenas.each do |arena| %>    
+                <li class="tab"><a href="#arena_<%= arena.id %>"><%= arena.name %></a></li>    
+            <% end %>
+        </ul>
+    </div>
+    <% @arenas.each do |arena| %>
+        <p></p>
+        <div id="arena_<%= arena.id %>" class="col s12">    
+            <p class="header right"><%= @date.strftime('%B of %Y') %></p>
+            <%= sync partial: 'arena', resource: arena %>
+            <p class="header"><%= arena.name %></p>
+        </div
+    <% end %>
+</div>
+
+ 
 
 <%= render 'form', schedule: @schedule %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -6,7 +6,12 @@
     </div>    
 </header>
 
-<p class="header">Select the desired arena and choose an available time.</p>
+<% if @arenas.empty? %>
+    <p class="header">No registered arena.</p>
+    <%= link_to 'New Arena', new_arena_path, class: "btn-flat teal lighten-5" %>
+<% else %>
+    <p class="header">Select the desired arena and choose an available time.</p>
+<% end %>
 
 <div class="row">
     <div class="col s12">

--- a/app/views/sync/arenas/_arena-admin.html.erb
+++ b/app/views/sync/arenas/_arena-admin.html.erb
@@ -1,0 +1,74 @@
+<p class="header right"><%= @date.strftime('%B of %Y') %></p>
+<div id="calendar-arena-<%= arena.id %>"></div>
+<script>
+    $("#calendar-arena-<%= arena.id %>").fullCalendar({
+        locale: 'en',
+        schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
+        events: [
+            <% (@date..@date.end_of_month).each do |date| %>
+                {
+                    title: '+ Add hour',
+                    start: '<%= date %>',
+                    color: '#fff'
+                },
+            <% end %>     
+            <% arena.current_hours.each do |hour| %>
+                {
+                    id: '<%= hour.id %>',
+                    title: '<%= hour.period! %>',
+                    start: '<%= hour.date %>',
+                    <% if !hour.available? %>
+                        color: '#e0e0e0',
+                        textColor: '#e0e0e0'
+                    <% end %>
+                },
+            <% end %>
+            
+        ],
+        eventClick: function(calEvent, jsEvent, view) {
+            if(calEvent.id) {
+                window.location.href += "/" + calEvent.id;
+            } else {
+                let chips = $('#chips-<%= arena.id %>');
+                let instance = M.Chips.getInstance(chips);
+                let date =  new Date(calEvent.start);
+                date.setDate(date.getDate() + 1);
+                instance.addChip({tag: date.toDateString()});
+                let form = $('#hour_form-<%= arena.id %>');
+                form.html("<input type='hidden' name='date[]' value='" + date.getDate() + "-" + (date.getMonth()+1) + "-" + date.getFullYear() + "'>" + form.html());
+            }
+        }
+    });
+
+    $('.chips').chips({
+        onChipAdd: () => { alert('teste') }
+    });
+</script>
+<p class="header">Select days with "Add hour" on calendar</p>
+<div class="chips" id="chips-<%= arena.id %>">
+    <input disabled>
+</div>
+
+<%= form_with(model: @hour, local: true, :html => { :id => "hour_form-#{arena.id}" }) do |form| %>
+    <%= form.hidden_field :arena_id, value: arena.id %>
+
+    <div class="input-field col s12">
+        <i class="material-icons prefix">hourglass_empty</i>
+        <%= form.text_field :time, :class => (@hour.errors[:time].count != 0 ? "validate invalid" : ""), id: "time_arena-#{arena.id}"  %>
+        <%= form.label :time, for: "time_arena-#{arena.id}" %>
+        <% @hour.errors[:time].each do |message| %>
+        <span class="helper-text" data-error="Time <%= message %>"></span>
+        <% end %>
+    </div>
+
+    <div class="input-field col s12">
+        <i class="material-icons prefix">attach_money</i>
+        <%= form.text_field :cost, :class => (@hour.errors[:cost].count != 0 ? "validate invalid" : ""), id: "cost_arena-#{arena.id}"  %>
+        <%= form.label :cost, for: "cost_arena-#{arena.id}" %>
+        <% @hour.errors[:cost].each do |message| %>
+        <span class="helper-text" data-error="Cost <%= message %>"></span>
+        <% end %>
+    </div>
+
+    <%= form.submit 'Submit', class: "btn-flat teal lighten-5" %>
+<% end %>

--- a/app/views/sync/arenas/_arena-admin.html.erb
+++ b/app/views/sync/arenas/_arena-admin.html.erb
@@ -39,14 +39,11 @@
             }
         }
     });
-
-    $('.chips').chips({
-        onChipAdd: () => { alert('teste') }
-    });
 </script>
-<p class="header">Select days with "Add hour" on calendar</p>
+<h4 class="header">New hours</h4>
 <div class="chips" id="chips-<%= arena.id %>">
     <input disabled>
+    <span class="helper-text">select days with "Add hour" on calendar</span>
 </div>
 
 <%= form_with(model: @hour, local: true, :html => { :id => "hour_form-#{arena.id}" }) do |form| %>
@@ -56,8 +53,9 @@
         <i class="material-icons prefix">hourglass_empty</i>
         <%= form.text_field :time, :class => (@hour.errors[:time].count != 0 ? "validate invalid" : ""), id: "time_arena-#{arena.id}"  %>
         <%= form.label :time, for: "time_arena-#{arena.id}" %>
+        <span class="helper-text">example: 20 for a time from 8 pm to 9 pm</span>
         <% @hour.errors[:time].each do |message| %>
-        <span class="helper-text" data-error="Time <%= message %>"></span>
+            <span class="helper-text" data-error="Time <%= message %>"></span>
         <% end %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :arenas do
     get :faye, on: :collection
   end
-
+  
   root 'schedules#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-admin = User.create([{ name: "Admin", address: "Address", cpf: "CPF", email: "admin@utfpr.edu.br", password: "123456", admin: true }])
+admin = User.create([{ name: "Admin", address: "Address", cpf: "018.317.100-48", email: "admin@utfpr.edu.br", password: "123456", admin: true }])


### PR DESCRIPTION
- [x] Legenda da arena para agendamento é muito pequena, adicionar como titulo;
- [x] Também adicionar o calendário para ajudar o admin na hora de cadastrar;
- [x] Exibir os horários que estão ocupados para melhor administração do admin;
- [ ] Ao cadastrar uma nova arena, utilizar as datas;
- [x] Confirmar o pagamento pelo admin, e não pelo usuário;
- [x] O usuário deveria acessar a arena antes do calendário para evitar pesquisar todas as arenas;

### Alguns gifs demonstrativos
Adicionado as Tabs para selecionar as arenas e também servem como titulo

![Arena select](https://user-images.githubusercontent.com/19733967/70394237-096a2800-19d2-11ea-8e46-fefea8960c17.gif)
Agora é possível adicionar um horário em vários dias ao mesmo tempo

![hours register](https://user-images.githubusercontent.com/19733967/70394238-096a2800-19d2-11ea-9224-8425dbbc7223.gif)

Agora o admin pode visualizar os horários no calendário e não em uma lista simples como antes

![Hours show](https://user-images.githubusercontent.com/19733967/70394239-096a2800-19d2-11ea-81a1-9937ff55c7ad.gif)
